### PR TITLE
Middlewares errors & try/catch

### DIFF
--- a/Middleware/catchErrors.js
+++ b/Middleware/catchErrors.js
@@ -1,0 +1,12 @@
+// Cette fonction exécute la méthode d'un controller et fait un try catch à sa place
+
+export default function catchErrors(controllerMethod) {
+  return async function (req, res, next) {
+    try {
+      await controllerMethod(req, res, next);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+s;

--- a/Middleware/errorMiddleware.js
+++ b/Middleware/errorMiddleware.js
@@ -1,0 +1,12 @@
+
+export default function notFound (_req, _res, next) {
+    const error = new Error('Not found')
+    error.statusCode = 404;
+    next(error)
+}
+
+export default function handlerError (error, req, res, next) {
+    const statusCode = error.statusCode || 500;
+
+    res.status(statusCode).json({message: error.message});
+}


### PR DESCRIPTION
Je me suis occupé des middlewares suivant : 
1. errorMiddleware.js : qui s'occupe du notFound et d'un handlerError
2. catchErrors.js : qui s'occupe du try/catch sur les routers* 

Exemple : `router.get('/ExampleRoute', catchErrors(getExamplePage));`

Bon dimanche !
